### PR TITLE
fix the nsfwcheck lambda iam role to include s3 access

### DIFF
--- a/aws/cf-template.yml
+++ b/aws/cf-template.yml
@@ -22,10 +22,10 @@ Resources:
                   - "s3:*"
                   - "cloudformation:DescribeStackResource"
                 Resource: "*"
-  IAMLambdaRekognitionAccessRole:
+  LambdaNSFWCheckAccessRole:
     Type: "AWS::IAM::Role"
     Properties:
-      RoleName: LambdaRekognitionAccessRole
+      RoleName: LambdaNSFWCheckAccessRole
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -34,13 +34,14 @@ Resources:
               Service: lambda.amazonaws.com
             Action: "sts:AssumeRole"
       Policies:
-        - PolicyName: LambdaRekognitionFullAccessPolicy
+        - PolicyName: LambdaNSFWCheckAccessToRekognitionAndS3Policy
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
               - Effect: Allow
                 Action:
                   - "rekognition:*"
+                  - "s3:*"
                 Resource: "*"
 
   GrayscalerLambda:
@@ -65,7 +66,7 @@ Resources:
     Properties:
       FunctionName: NSFWCheckerLambda
       Handler: "index.handler"
-      Role: !GetAtt IAMLambdaRekognitionAccessRole.Arn
+      Role: !GetAtt LambdaNSFWCheckAccessRole.Arn
       Code:
         ZipFile: |
           exports.handler = (event, context, callback) => {


### PR DESCRIPTION
## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
The IAM Role assigned to the NSFWCheck lambda did not contain access to S3 buckets - this was corrected now and the lambda can work properly.

## What is the current behavior? (You can also link to an open issue here)
Error received due to the lambda not being able to access the S3 buckets for Rekognition.

## What is the new behavior (if this is a feature change)?
NSFWCheck Lambda is able to access s3 & Rekognition, so when testing it via an example input (bucket name and object key) it will successfully complete.

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

## Other information:
