### PR TITLE
add logging for lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ The output is a JSON containing if the picture is NSFW and the bucket name and k
 ## To improve
 - Restrict the created IAM role to only the created buckets.
 - Introduce step functions to the CF Stack.
-- Turn on logging for the Lambda functions.
 - Improve the S3 bucket creation by enabling AWS EventBridge integration by default.
 - Add AWS EventBridge to the CF Stack.
 - Add AWS SNS to the stack - the plan is to publish a message here when a picture is deemed NSFW.

--- a/aws/cf-template.yml
+++ b/aws/cf-template.yml
@@ -1,10 +1,11 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: "An example CF template to work with the image processing lambda and step function"
 Resources:
-  IAMLambdaS3AccessRole:
+  ######################## IAM ROLES ########################
+  LambdaGrayscalerAccessRole:
     Type: "AWS::IAM::Role"
     Properties:
-      RoleName: LambdaS3AccessRole
+      RoleName: LambdaGrayscalerAccessRole
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -20,8 +21,17 @@ Resources:
               - Effect: Allow
                 Action:
                   - "s3:*"
-                  - "cloudformation:DescribeStackResource"
                 Resource: "*"
+        - PolicyName: LoggingPolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:*:*:log-group:/aws/lambda/GrayscalerLambda:*
+
   LambdaNSFWCheckAccessRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -43,7 +53,28 @@ Resources:
                   - "rekognition:*"
                   - "s3:*"
                 Resource: "*"
+        - PolicyName: LoggingPolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:*:*:log-group:/aws/lambda/NSFWCheckerLambda:*
+  ######################## LOGGING ########################
+  GrayscalerLogGroup:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName: /aws/lambda/GrayscalerLambda
+      RetentionInDays: 30
 
+  NsfwcheckLogGroup:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName: /aws/lambda/NSFWCheckerLambda
+      RetentionInDays: 30
+  ######################## LAMBDAS ########################
   GrayscalerLambda:
     Type: "AWS::Lambda::Function"
     Properties:
@@ -52,7 +83,7 @@ Resources:
           OUT_BUCKET: !Ref ImageOutBucket
       FunctionName: GrayscalerLambda
       Handler: "index.handler"
-      Role: !GetAtt IAMLambdaS3AccessRole.Arn
+      Role: !GetAtt LambdaGrayscalerAccessRole.Arn
       Code:
         ZipFile: |
           exports.handler = (event, context, callback) => {
@@ -60,6 +91,8 @@ Resources:
           };
       Runtime: "nodejs18.x"
       Timeout: "30"
+      TracingConfig:
+        Mode: Active
 
   NSFWCheckerLambda:
     Type: "AWS::Lambda::Function"
@@ -73,9 +106,10 @@ Resources:
               callback(null, "Hello World!");
           };
       Runtime: "nodejs18.x"
-      Timeout: "60"
-      MemorySize: 512
-  
+      Timeout: "30"
+      TracingConfig:
+        Mode: Active
+  ######################## S3 Buckets ########################
   ImageInBucket:
     Type: "AWS::S3::Bucket"
     Properties:


### PR DESCRIPTION
## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Adds logging to cloudwatch logstreams for the created lambdas.

## What is the current behavior? (You can also link to an open issue here)
No logs are produced.

## What is the new behavior (if this is a feature change)?
Logging is enabled and each aws lambda receives a log group.

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

## Other information:
