### PR TITLE
Add starter step function and event bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ The output is a JSON containing if the picture is NSFW and the bucket name and k
 ## To improve
 - Restrict the created IAM role to only the created buckets.
 - Introduce step functions to the CF Stack.
-- Improve the S3 bucket creation by enabling AWS EventBridge integration by default.
 - Add AWS EventBridge to the CF Stack.
 - Add AWS SNS to the stack - the plan is to publish a message here when a picture is deemed NSFW.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ The output is a JSON containing if the picture is NSFW and the bucket name and k
 ## To improve
 - Restrict the created IAM role to only the created buckets.
 - Introduce step functions to the CF Stack.
-- Add AWS EventBridge to the CF Stack.
 - Add AWS SNS to the stack - the plan is to publish a message here when a picture is deemed NSFW.
 
 The general aim is to have a stepfunction similar to this:  

--- a/aws/cf-template.yml
+++ b/aws/cf-template.yml
@@ -62,6 +62,44 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: arn:aws:logs:*:*:log-group:/aws/lambda/NSFWCheckerLambda:*
+
+  ImageProcessingEventRuleRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: EventBridgeExecutionPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: states:startExecution
+                Resource: !GetAtt ImageProcessingStateMachine.Arn
+
+  ImageProcessingStateMachineRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: states.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: StepFunctionExecutionPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: lambda:InvokeFunction
+                Resource: "*"
   ######################## LOGGING ########################
   GrayscalerLogGroup:
     Type: 'AWS::Logs::LogGroup'
@@ -134,25 +172,7 @@ Resources:
         Rules:
           - ObjectOwnership: ObjectWriter
 
-  MyEventRuleRole:
-    Type: "AWS::IAM::Role"
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: events.amazonaws.com
-            Action: sts:AssumeRole
-      Policies:
-        - PolicyName: EventBridgeExecutionPolicy
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action: states:startExecution
-                Resource: !GetAtt MyStateMachine.Arn
-
+  ######################## Event Bridge ########################
   ImageProcessingEventBridgeRule:
     Type: "AWS::Events::Rule"
     Properties:
@@ -167,33 +187,15 @@ Resources:
               - !Ref ImageInBucket
       State: ENABLED
       Targets:
-        - Arn: !GetAtt MyStateMachine.Arn
+        - Arn: !GetAtt ImageProcessingStateMachine.Arn
           Id: "InvokeStateMachine"
-          RoleArn: !GetAtt MyEventRuleRole.Arn
+          RoleArn: !GetAtt ImageProcessingEventRuleRole.Arn
 
-  MyStateMachineRole:
-    Type: "AWS::IAM::Role"
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: states.amazonaws.com
-            Action: sts:AssumeRole
-      Policies:
-        - PolicyName: StepFunctionExecutionPolicy
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action: lambda:InvokeFunction
-                Resource: "*"
-
-  MyStateMachine:
+  ######################## State Machine ########################
+  ImageProcessingStateMachine:
     Type: "AWS::StepFunctions::StateMachine"
     Properties:
-      RoleArn: !GetAtt MyStateMachineRole.Arn
+      RoleArn: !GetAtt ImageProcessingStateMachineRole.Arn
       DefinitionString:
         !Sub |
         {

--- a/aws/cf-template.yml
+++ b/aws/cf-template.yml
@@ -133,3 +133,76 @@ Resources:
       OwnershipControls:
         Rules:
           - ObjectOwnership: ObjectWriter
+
+  MyEventRuleRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: EventBridgeExecutionPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: states:startExecution
+                Resource: !GetAtt MyStateMachine.Arn
+
+  ImageProcessingEventBridgeRule:
+    Type: "AWS::Events::Rule"
+    Properties:
+      EventPattern:
+        source:
+          - "aws.s3"
+        detail-type:
+          - "Object Created"
+        detail:
+          bucket:
+            name:
+              - !Ref ImageInBucket
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt MyStateMachine.Arn
+          Id: "InvokeStateMachine"
+          RoleArn: !GetAtt MyEventRuleRole.Arn
+
+  MyStateMachineRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: states.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: StepFunctionExecutionPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: lambda:InvokeFunction
+                Resource: "*"
+
+  MyStateMachine:
+    Type: "AWS::StepFunctions::StateMachine"
+    Properties:
+      RoleArn: !GetAtt MyStateMachineRole.Arn
+      DefinitionString:
+        !Sub |
+        {
+          "StartAt": "InvokeLambda",
+          "States": {
+            "InvokeLambda": {
+              "Type": "Task",
+              "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:NSFWCheckerLambda",
+              "End": true
+            }
+          }
+        }

--- a/aws/cf-template.yml
+++ b/aws/cf-template.yml
@@ -113,6 +113,9 @@ Resources:
   ImageInBucket:
     Type: "AWS::S3::Bucket"
     Properties:
+      NotificationConfiguration:
+        EventBridgeConfiguration:
+          EventBridgeEnabled: true
       PublicAccessBlockConfiguration:
         BlockPublicAcls: false
       OwnershipControls:
@@ -122,6 +125,9 @@ Resources:
   ImageOutBucket:
     Type: "AWS::S3::Bucket"
     Properties:
+      NotificationConfiguration:
+        EventBridgeConfiguration:
+          EventBridgeEnabled: true
       PublicAccessBlockConfiguration:
         BlockPublicAcls: false
       OwnershipControls:


### PR DESCRIPTION
## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Adds a starter stepfunction.

## What is the current behavior? (You can also link to an open issue here)
No stepfunction is present in the stack.

## What is the new behavior (if this is a feature change)?
A new stepfunction is created as well as an event bridge rule.
The event bridge rule is triggered when an object created event is triggered by the input S3 bucket, the rules target is the created stepfunction.
The step function is simple - it invokes the NSFWCheck lambda function.

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

## Other information:
